### PR TITLE
Skip bucket existence validation

### DIFF
--- a/yas3fs/__init__.py
+++ b/yas3fs/__init__.py
@@ -851,7 +851,7 @@ class YAS3FS(LoggingMixIn, Operations):
         if not self.s3:
             error_and_exit("no S3 connection")
         try:
-            self.s3_bucket = self.s3.get_bucket(self.s3_bucket_name, headers=self.default_headers)
+            self.s3_bucket = self.s3.get_bucket(self.s3_bucket_name, headers=self.default_headers, validate=False)
             self.s3_bucket.key_class = UTF8DecodingKey
         except boto.exception.S3ResponseError, e:
             error_and_exit("S3 bucket not found:" + str(e))
@@ -1216,7 +1216,7 @@ class YAS3FS(LoggingMixIn, Operations):
                 self.s3_prefix = s3url.path.strip('/')
                 logger.info("S3 prefix: '%s'" % self.s3_prefix)
                 try:
-                    self.s3_bucket = self.s3.get_bucket(self.s3_bucket_name, headers=self.default_headers)
+                    self.s3_bucket = self.s3.get_bucket(self.s3_bucket_name, headers=self.default_headers, validate=False)
                     self.s3_bucket.key_class = UTF8DecodingKey
                 except boto.exception.S3ResponseError, e:
                     error_and_exit("S3 bucket not found:" + str(e))


### PR DESCRIPTION
This allows yas3fs to work with minimal IAM policies, per:

http://stackoverflow.com/questions/11478752/with-the-boto-library-can-i-avoid-granting-list-permissions-on-a-base-bucket-in

e.g.

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Stmt1422406089000",
      "Effect": "Allow",
      "Action": [
        "s3:ListBucket"
      ],
      "Resource": [
        "arn:aws:s3:::bucket.example.com"
      ],
      "Condition": {
        "StringLike": {
          "s3:prefix": "prefix/*"
        }
      }
    },
    {
      "Effect":"Allow",
      "Action":[
        "s3:GetObject"
      ],
      "Resource":[
        "arn:aws:s3:::bucket.example.com/prefix/*"
      ]
    }
  ]
}
```