### PR TITLE
do_cmd_on_s3_now s3 content type lost

### DIFF
--- a/yas3fs/__init__.py
+++ b/yas3fs/__init__.py
@@ -2064,6 +2064,8 @@ class YAS3FS(LoggingMixIn, Operations):
                 del self.cache.entries[path]
 
             elif action == 'copy':
+                # Otherwise we loose the Content-Type with S3 Copy
+                key.metadata['Content-Type'] = key.content_type
                 key.copy(*args, **kargs)
 
                 path = self.remove_prefix(args[1])

--- a/yas3fs/__init__.py
+++ b/yas3fs/__init__.py
@@ -54,6 +54,9 @@ from YAS3FSPlugin import YAS3FSPlugin
 
 from _version import __version__
 
+mimetypes.add_type("image/svg+xml", ".svg", True)
+mimetypes.add_type("image/svg+xml", ".svgz", True)
+
 class UTF8DecodingKey(boto.s3.key.Key):
     BufferSize = 131072
 


### PR DESCRIPTION
when action copy executed within do_cmd_on_s3_now the content-type attribute was lost, much like within rename_on_s3.

this happened with non multipart uploads, set_contents_from_file seems to write the headers (attributes and content-type) as it should, but the copy action gets executed for some reason and it loses the content-type.

also see http://stackoverflow.com/questions/9136490/boto-s3-copy-on-a-key-object-loses-content-type-metadata