### PR TITLE
Enable dotted bucket names.

### DIFF
--- a/yas3fs/__init__.py
+++ b/yas3fs/__init__.py
@@ -43,6 +43,7 @@ from fuse import FUSE, FuseOSError, Operations, LoggingMixIn, fuse_get_context
 
 import boto
 import boto.s3
+import boto.s3.connection
 import boto.sns
 import boto.sqs
 import boto.utils
@@ -848,11 +849,12 @@ class YAS3FS(LoggingMixIn, Operations):
         if not self.aws_region in (r.name for r in boto.s3.regions()):
             error_and_exit("wrong AWS region '%s' for S3" % self.aws_region)
         try:
+            calling_format = boto.s3.connection.OrdinaryCallingFormat()
             if options.s3_use_sigv4:
                 os.environ['S3_USE_SIGV4'] = 'True'
-                self.s3 = boto.connect_s3(host=options.s3_endpoint)
+                self.s3 = boto.connect_s3(host=options.s3_endpoint, calling_format=calling_format)
             else:
-                self.s3 = boto.connect_s3()
+                self.s3 = boto.connect_s3(calling_format=calling_format)
         except boto.exception.NoAuthHandlerFound:
             error_and_exit("no AWS credentials found")
         if not self.s3:

--- a/yas3fs/__init__.py
+++ b/yas3fs/__init__.py
@@ -1888,6 +1888,8 @@ class YAS3FS(LoggingMixIn, Operations):
                         data.set('range', FSRange())
                     logger.debug("check_data '%s' created empty data object" % (path))
                 else: # Download at once
+                    if data.content is None:
+                        data.open()
                     k.get_contents_to_file(data.content, headers = self.default_headers)
                     data.update_size()
                     data.update_etag(k.etag[1:-1])


### PR DESCRIPTION
This is a patch that allows dotted bucket names.

This works by changing the calling format from `https://bucket-name.s3.amazonaws.com/` to `https://s3-region.amazonaws.com/bucket-name` (or `s3.region.amazonaws.com` for newer regions).

Changing the format requires specifying `OrdinaryCallingFormat()` in the S3 connection. However, without an endpoint, this always defaults to us-east-1; further requests cause S3 to throw a 301 (Moved Permanently) response, which Boto can't handle. Thus, we also check the bucket location after connecting if the endpoint hasn't been specified and reconnect to the proper endpoint for the bucket's region.