### PR TITLE
Support native S3 events

### DIFF
--- a/yas3fs/__init__.py
+++ b/yas3fs/__init__.py
@@ -1276,16 +1276,14 @@ class YAS3FS(LoggingMixIn, Operations):
         event_kind = event['eventName']
         path = '/'+event['s3']['object']['key']
         user_id = event['userIdentity']['principalId']
-        logger.debug("Native S3 event %s on %s by %s" % (event_kind, path, user_id))
 
         if user_id == self.current_user_principalId:
-            logger.debug("Native S3 event from current yas3fs user discarded")
+            logger.debug("Native S3 event %s on %s from current yas3fs user %s discarded" % (event_kind, path, user_id))
             return
 
-        if event_kind.startswith('ObjectCreated'):
-            self.delete_cache(path)
-        elif event_kind.startswith('ObjectRemoved'):
-            self.delete_cache(path)
+        logger.info("Native S3 event %s on %s by %s. Deleting cache for %s" % (event_kind, path, user_id, path))
+
+        self.delete_cache(path)
 
     def publish_status(self):
         hostname = socket.getfqdn()

--- a/yas3fs/__init__.py
+++ b/yas3fs/__init__.py
@@ -1154,7 +1154,6 @@ class YAS3FS(LoggingMixIn, Operations):
                     if content.has_key('Message'):
                         message = content['Message'].encode('ascii')
                         self.process_message(message)
-                        m.delete()
                     elif content.has_key('Records'):
                         # Support S3 native bucket events
                         for event in content['Records']:
@@ -1162,6 +1161,7 @@ class YAS3FS(LoggingMixIn, Operations):
                     else:
                         # eg: "Service":"Amazon S3","Event":"s3:TestEvent"...
                         logger.warn("Unknown SQS message: "+repr(content))
+                    m.delete()
 
 
             else:

--- a/yas3fs/__init__.py
+++ b/yas3fs/__init__.py
@@ -1274,18 +1274,18 @@ class YAS3FS(LoggingMixIn, Operations):
 
     def process_native_s3_event(self, event):
         event_kind = event['eventName']
-        prefix = event['s3']['object']['key']
+        path = '/'+event['s3']['object']['key']
         user_id = event['userIdentity']['principalId']
-        logger.debug("Native S3 event %s on %s by %s" % (event_kind, prefix, user_id))
+        logger.debug("Native S3 event %s on %s by %s" % (event_kind, path, user_id))
 
         if user_id == self.current_user_principalId:
             logger.debug("Native S3 event from current yas3fs user discarded")
             return
 
         if event_kind.startswith('ObjectCreated'):
-            self.delete_cache(prefix)
+            self.delete_cache(path)
         elif event_kind.startswith('ObjectRemoved'):
-            self.delete_cache(prefix)
+            self.delete_cache(path)
 
     def publish_status(self):
         hostname = socket.getfqdn()

--- a/yas3fs/__init__.py
+++ b/yas3fs/__init__.py
@@ -1274,7 +1274,7 @@ class YAS3FS(LoggingMixIn, Operations):
 
     def process_native_s3_event(self, event):
         event_kind = event['eventName']
-        path = '/'+event['s3']['object']['key']
+        path = '/'+event['s3']['object']['key'].strip('/')  # want '/abc/folder' while on s3 it's 'abc/folder/'
         user_id = event['userIdentity']['principalId']
 
         if user_id == self.current_user_principalId:

--- a/yas3fs/__init__.py
+++ b/yas3fs/__init__.py
@@ -1283,7 +1283,7 @@ class YAS3FS(LoggingMixIn, Operations):
             return
 
         if event_kind.startswith('ObjectCreated'):
-            self.invalidate_cache(prefix)
+            self.delete_cache(prefix)
         elif event_kind.startswith('ObjectRemoved'):
             self.delete_cache(prefix)
 


### PR DESCRIPTION
Closes #146.
With this PR, it is possible to mount an S3 bucket that's being modified in parallel from outside of yas3fs.
This is achieved by configuring the bucket to send automatic events to the SQS queue which is monitored by yas3fs.
In this PR, we identify events caused by yas3fs itself via the user_id of the event initiator. This restricts the solution to have the same AWS user run yas3fs on all nodes which participate in a cluster where native S3 events are configured.
